### PR TITLE
Fix: Corrected labelDisplayUnits type in Card.json to prevent theme crash in Power BI

### DIFF
--- a/Card.json
+++ b/Card.json
@@ -9,7 +9,7 @@
 				}],
 				"labels": [{
 					"color": { "solid": { "color": "#000000"}},
-					"labelDisplayUnits": "0",
+					"labelDisplayUnits": 0,
 					"labelPrecision": 0,
 					"fontSize": 10,
 					"fontFamily": "Verdana"
@@ -45,3 +45,4 @@
 		}
 	}
 }
+


### PR DESCRIPTION
### Summary
This PR fixes a schema validation bug in `Card.json` where `labelDisplayUnits` was defined as a string ("0") instead of an integer (0).

### Problem
<img width="632" height="507" alt="image" src="https://github.com/user-attachments/assets/341f7406-d487-4d77-a9c6-63848fbf7379" />

- Current schema requires `labelDisplayUnits` to be one of the integer values: 0, 1, 1000, 1000000, 1000000000, 1000000000000.
- Using a string causes Power BI themes to fail validation and crash in version 2.146.1254.0 (August 2025).

### Fix
- Changed `"labelDisplayUnits": "0"` → `"labelDisplayUnits": 0`.

### Impact
- Theme now imports without errors in the latest Power BI Desktop (2.146.1254.0 64-bit).
- Ensures backward compatibility with earlier versions.

### After Resolution of Problem
<img width="917" height="135" alt="image" src="https://github.com/user-attachments/assets/024bcc6a-1edf-4d68-a3da-66bf98ce5ea1" />

